### PR TITLE
add pipeline environment variable context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,13 @@ jobs:
 workflows:
   test:
     jobs:
-      - lint
+      - lint:
+          context: cas-pipeline
       - build:
+          context: cas-pipeline
           requires:
             - lint
       - test-local-cluster:
+          context: cas-pipeline
           requires:
             - lint


### PR DESCRIPTION
An example use of a CircleCI security context to provide the following environment variables to authorized testers:
OC_SERVER_ADDRESS
OC_TOKEN
RED_HAT_DOCKER_EMAIL
RED_HAT_DOCKER_PASSWORD
RED_HAT_DOCKER_SERVER
RED_HAT_DOCKER_USERNAME